### PR TITLE
Update ICS exporter to encode reserved chars

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -158,7 +158,7 @@ describe('Calendar Links', () => {
       const eTime: string = dayjs(event.start).add(1, 'day').utc().format(TimeFormats.allDay)
 
       const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${document.URL}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0ADESCRIPTION:%0ALOCATION:undefined%0AEND:VEVENT%0AEND:VCALENDAR`)
+      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
     })
     test('should generate an ics link', () => {
       const event: CalendarEvent = {
@@ -170,7 +170,7 @@ describe('Calendar Links', () => {
       const eTime: string = dayjs(event.start).add(2, 'day').utc().format(TimeFormats.dateTimeUTC)
 
       const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${document.URL}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0ADESCRIPTION:%0ALOCATION:undefined%0AEND:VEVENT%0AEND:VCALENDAR`)
+      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
     })
     
     test('should generate an ics link with end date', () => {
@@ -183,7 +183,22 @@ describe('Calendar Links', () => {
       const eTime: string = dayjs(event.end).utc().format(TimeFormats.dateTimeUTC)
 
       const link = ics(event)
-      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${document.URL}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0ADESCRIPTION:%0ALOCATION:undefined%0AEND:VEVENT%0AEND:VCALENDAR`)
+      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:Birthday%20party%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
+    })
+
+    test('should generate an ics link with escaped characters', () => {
+      const event: CalendarEvent = {
+        title: "!#$%&'()*+,/:;=?@[] — Birthday party",
+        description: "!#$%&'()*+,/:;=?@[] — My birthday!",
+        location: "!#$%&'()*+,/:;=?@[] — My birthday!",
+        start: "2019-12-23",
+        end: "2019-12-29"
+      }
+      const sTime: string = dayjs(event.start).utc().format(TimeFormats.dateTimeUTC)
+      const eTime: string = dayjs(event.end).utc().format(TimeFormats.dateTimeUTC)
+
+      const link = ics(event)
+      expect(link).toBe(`data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0AURL:${encodeURIComponent(document.URL)}%0ADTSTART:${sTime}%0ADTEND:${eTime}%0ASUMMARY:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20Birthday%20party%0ADESCRIPTION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0ALOCATION:!%23%24%25%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%E2%80%94%20My%20birthday!%0AEND:VEVENT%0AEND:VCALENDAR%0A`)
     })
   })
 })

--- a/index.ts
+++ b/index.ts
@@ -103,19 +103,60 @@ export const ics = (event: CalendarEvent) => {
   const end: string = dayjs(event.end)
     .utc()
     .format(format);
-  const calendarUrl: string = [
-    "BEGIN:VCALENDAR",
-    "VERSION:2.0",
-    "BEGIN:VEVENT",
-    `URL:${document.URL}`,
-    `DTSTART:${start}`,
-    `DTEND:${end}`,
-    `SUMMARY:${event.title}`,
-    `DESCRIPTION:${formattedDescription}`,
-    `LOCATION:${event.location}`,
-    "END:VEVENT",
-    "END:VCALENDAR"
-  ].join("\n");
+  const calendarChunks = [
+    {
+      key: 'BEGIN',
+      value: 'VCALENDAR'
+    },
+    {
+      key: 'VERSION',
+      value: '2.0'
+    },
+    {
+      key: 'BEGIN',
+      value: 'VEVENT'
+    },
+    {
+      key: 'URL',
+      value: document.URL
+    },
+    {
+      key: 'DTSTART',
+      value: start
+    },
+    {
+      key: 'DTEND',
+      value: end
+    },
+    {
+      key: 'SUMMARY',
+      value: event.title
+    },
+    {
+      key: 'DESCRIPTION',
+      value: formattedDescription
+    },
+    {
+      key: 'LOCATION',
+      value: event.location
+    },
+    {
+      key: 'END',
+      value: 'VEVENT'
+    },
+    {
+      key: 'END',
+      value: 'VCALENDAR'
+    },
+  ];
 
-  return encodeURI("data:text/calendar;charset=utf8," + calendarUrl);
+  let calendarUrl: string = '';
+
+  calendarChunks.forEach(chunk => {
+    if(chunk.value) {
+      calendarUrl += `${chunk.key}:${encodeURIComponent(`${chunk.value}\n`)}`;
+    }
+  });
+
+  return `data:text/calendar;charset=utf8,${calendarUrl}`;
 };


### PR DESCRIPTION
The ICS generator creates a data URI.
Unescaped reserved chars like `#` and `?` can break the URL
Escaping these sections resolves this.
I changed the structure of the code to do this without double encoding.

Also updates tests to match.

---

Fixes #84